### PR TITLE
Python3 can also raise AttributeError while pickling.

### DIFF
--- a/teres/__init__.py
+++ b/teres/__init__.py
@@ -96,7 +96,7 @@ def dump_tb(tb):
         try:
             pickle.dumps(obj)
             return obj
-        except (TypeError, pickle.PicklingError):
+        except (TypeError, AttributeError, pickle.PicklingError):
             return repr(obj)
 
     dump = []


### PR DESCRIPTION
Example:
AttributeError: Can't pickle local object 'AnabotPredicate._genCompareFunc.<locals>.satisfiedByNode'